### PR TITLE
Fix bug where co-authorship options are not displayed

### DIFF
--- a/src/web/app/src/store/data/requiredDataSets.js
+++ b/src/web/app/src/store/data/requiredDataSets.js
@@ -1,5 +1,5 @@
 export default {
-  "Co-authorship": ["AuthorRecord", "ReviewRecord", "SubmissionRecord"],
+  "Co-authorship": ["AuthorRecord", "SubmissionRecord"],
   "Submission Record": ["SubmissionRecord"],
   "Review Record": ["ReviewRecord"],
   "Author Record": ["AuthorRecord"],


### PR DESCRIPTION
Co-authorship charts seem to only require author record and submission record.